### PR TITLE
Change DS_MAD config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For OpenNebula 5.0 we also need to  create a new DS_MAD_CONF section:
 
 ~~~~
 DS_MAD_CONF = [
-    NAME = "zfs", REQUIRED_ATTRS = "DISK_TYPE", PERSISTENT_ONLY = "YES"
+    NAME = "zfs", REQUIRED_ATTRS = "DISK_TYPE", PERSISTENT_ONLY = "NO"
 ]
 ~~~~
 


### PR DESCRIPTION
Setting 
```PERSISTENT_ONLY``` to NO also seems to work.

The setting is required, but it doesn't have to be set to "YES".
Setting it to NO allows to use marketplace apps as per #7 and also is matching with the normal datastore feature set.
Setting it to YES seems primarily required when the datastore driver cannot copy (create) volumes by itself.